### PR TITLE
v1.1.1

### DIFF
--- a/.mdlrc
+++ b/.mdlrc
@@ -1,2 +1,2 @@
 all
-rules "~MD013", "~MD026", "~MD033"
+rules "~MD013", "~MD024", "~MD026", "~MD033"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-# MMM-WienerLinien Changelog
+# MMM-Fuel Changelog
+
+## [1.1.1]
+
+### Added
+
+* Disabled markdownlint rule `MD024` (no-duplicate-header)
+* Config option `toFixed` to show only 2 decimals for the price.
+
+### Changed
+
+* Coordinate.to() throws exception if start point is not set.
 
 ## [1.1.0]
 

--- a/MMM-Fuel.js
+++ b/MMM-Fuel.js
@@ -68,6 +68,7 @@ Module.register('MMM-Fuel', {
      * @property {int} rotateInterval - Speed of rotation.
      * @property {int} updateInterval - Speed of update.
      * @property {string} provider - API provider of the data.
+     * @property {boolean} toFixed - Flag to show price with only 2 decimals.
      */
     defaults: {
         radius: 5,
@@ -87,7 +88,8 @@ Module.register('MMM-Fuel', {
         sortBy: 'diesel',
         rotateInterval: 60 * 1000, // every minute
         updateInterval: 15 * 60 * 1000, // every 15 minutes
-        provider: 'tankerkoenig'
+        provider: 'tankerkoenig',
+        toFixed: false
     },
 
     /**
@@ -108,6 +110,7 @@ Module.register('MMM-Fuel', {
     /**
      * @function getTranslations
      * @description Translations for this module.
+     * @override
      *
      * @returns {Object.<string, string>} Available translations for this module (key: language code, value: filepath).
      */
@@ -121,6 +124,7 @@ Module.register('MMM-Fuel', {
     /**
      * @function getStyles
      * @description Style dependencies for this module.
+     * @override
      *
      * @returns {string[]} List of the style dependency filepaths.
      */
@@ -164,6 +168,7 @@ Module.register('MMM-Fuel', {
     /**
      * @function notificationReceived
      * @description Handles incoming broadcasts from other modules or the MagicMirror core.
+     * @override
      *
      * @param {string} notification - Notification name
      * @param {*} payload - Detailed payload of the notification.
@@ -184,6 +189,7 @@ Module.register('MMM-Fuel', {
     /**
      * @function socketNotificationReceived
      * @description Handles incoming messages from node_helper.
+     * @override
      *
      * @param {string} notification - Notification name
      * @param {*} payload - Detailed payload of the notification.
@@ -407,7 +413,8 @@ Module.register('MMM-Fuel', {
                 if (data.prices[this.config.types[i]] === -1) {
                     price.innerHTML = '-';
                 } else {
-                    price.innerHTML = `${data.prices[this.config.types[i]].toFixed(2)} ${
+                    price.innerHTML = `${this.config.toFixed ?
+                        data.prices[this.config.types[i]].toFixed(2) : data.prices[this.config.types[i]]} ${
                         this.currencies[this.priceList.currency]}`;
                 }
                 row.appendChild(price);
@@ -482,7 +489,7 @@ Module.register('MMM-Fuel', {
     },
 
     /**
-     * @function appendTo
+     * @function appendHelp
      * @description Creates the UI for the voice command SHOW HELP.
      *
      * @param {Element} appendTo - DOM Element where the UI gets appended as child.

--- a/apis/utils/Coordinate.js
+++ b/apis/utils/Coordinate.js
@@ -59,16 +59,22 @@ module.exports = {
      * @param {number} distance - Distance in kilometres to the target.
      * @returns {Object.<string, number>} Target Coordinate.
      *
+     * @throws {Error} Error gets thrown if the start Coordinate wasn't set.
+     *
      * @see https://github.com/chrisveness/geodesy
      */
     to(degree, distance) {
+        const φ1 = deg2rad(this.lat);
+        const λ1 = deg2rad(this.lng);
+
+        if (!φ1 || !φ1) {
+            throw new Error('No start Coordinate set!');
+        }
+
         const radius = distance * 1000;
 
         const δ = Math.sqrt(2 * (radius * radius)) / earth;
         const θ = deg2rad(Number(degree));
-
-        const φ1 = deg2rad(this.lat);
-        const λ1 = deg2rad(this.lng);
 
         const sinφ1 = Math.sin(φ1);
         const cosφ1 = Math.cos(φ1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmm-fuel",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Gas Station price Module for MagicMirror2",
   "scripts": {
     "lint": "./node_modules/.bin/eslint . && ./node_modules/.bin/stylelint .",


### PR DESCRIPTION
* Disabled markdownlint rule `MD024` (no-duplicate-header)
* Config option `toFixed` to show only 2 decimals for the price.
* Coordinate.to() throws exception if start point is not set.