### PR TITLE
Log a warning if a fuel station detail couldn't be fetched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+* Log a warning if no fuel station detail could be fetched
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+* Filtering of station ids lead to invalid price request for provider tankerkoenig
+
 ### Added
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 ### Added
 
 ### Changed
+
 * Log a warning if no fuel station detail could be fetched
+* Updated provider integration documentation
 
 ### Removed
 

--- a/apis/README.md
+++ b/apis/README.md
@@ -31,8 +31,8 @@ The response has to have the following format:
 ```
 {
     types: ['diesel', 'e5', 'e10'], // Array | types supported by the API provider.
-    unit: 'km', // String | unit for the distance either in kilometres (km) or miles (ml).
-    currency: 'EUR', // String | curreny of the fuel prices either in EUR or USD.
+    unit: 'km', // String | unit for the distance either `kilometer` or `mile`.
+    currency: 'EUR', // String | 3 character representation of the currency for the fuel prices e.g. `EUR`, `USD` or `AUD`.
     byPrice: stations, // Array | stations (see above) sorted by price.
     byDistance: distance // Array | stations (see above) sorted by distance.
 };

--- a/apis/tankerkoenig.js
+++ b/apis/tankerkoenig.js
@@ -186,7 +186,7 @@ async function setStationInfos(stationsByRadius) {
         const parsedResponse = await response.json();
 
         if (!parsedResponse.ok) {
-            console.warn(`No fuel station detail. StationId: ` + stationId + ` Error: ` + parsedResponse.message);
+            console.warn(`No fuel station detail. StationId: ${stationId} Error: ${parsedResponse.message}`);
             continue;
         }
 

--- a/apis/tankerkoenig.js
+++ b/apis/tankerkoenig.js
@@ -168,10 +168,8 @@ async function getPricesByRadius() {
  * @returns {void}
  */
 async function setStationInfos(stationsByRadius) {
-
-    // Filter out possible duplicate stations which are included in the radius search.
     for (const station of stationsByRadius) {
-        config.stationIds = config.stationIds.filter(e => e !== station.id);
+        config.stationIds = config.stationIds.filter(id => id !== station.id);
     }
 
     if (config.stationIds.length > 10) {
@@ -186,7 +184,7 @@ async function setStationInfos(stationsByRadius) {
         const parsedResponse = await response.json();
 
         if (!parsedResponse.ok) {
-            console.warn(`No fuel station detail. StationId: ${stationId} Error: ${parsedResponse.message}`);
+            console.warn(`MMM-Fuel: No fuel station detail. StationId: ${stationId} Error: ${parsedResponse.message}`);
             continue;
         }
 
@@ -241,14 +239,21 @@ async function getPricesByStationList(stationsByRadius) {
         await setStationInfos(stationsByRadius);
     }
 
-    const response = await fetch(generateStationPricesUrl(Object.keys(stationInfos)));
+    const stationIds = Object.keys(stationInfos);
+    const stations = [];
+
+    if (!stationIds.length) {
+        console.warn('MMM-Fuel: Filtered stationIds list is empty');
+        return stations;
+    }
+
+    const response = await fetch(generateStationPricesUrl(stationIds));
     const parsedResponse = await response.json();
 
     if (!parsedResponse.ok) {
         throw new Error('Error no fuel station prices');
     }
 
-    const stations = [];
     for (const [stationId, info] of Object.entries(parsedResponse.prices)) {
         stations.push({
             ...stationInfos[stationId],

--- a/apis/tankerkoenig.js
+++ b/apis/tankerkoenig.js
@@ -186,7 +186,8 @@ async function setStationInfos(stationsByRadius) {
         const parsedResponse = await response.json();
 
         if (!parsedResponse.ok) {
-            throw new Error('Error no fuel station detail');
+            console.warn(`No fuel station detail. StationId: ` + stationId + ` Error: ` + parsedResponse.message);
+            continue;
         }
 
         const station = parsedResponse.station;


### PR DESCRIPTION
Log a warning with helpful information if a fuel station detail could not be fetched. In my case I used a station id for a fuel station that is no longer valid. Throwing a error without further information was confusing. I think logging a warning is the better approach here.

![grafik](https://user-images.githubusercontent.com/9296618/113521358-411ebb00-9599-11eb-974f-649bf793d315.png)
