### PR TITLE
Added option to exclude stations from radius

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # MMM-Fuel Changelog
 
-## [2.3.1]
-
-### Added
-
-* Config option `excludeStationIds` to exclude gas stations from radius (Tankerkönig only)
-
 ## [2.3.0]
 
 MagicMirror² version >= 2.15.0 required.
@@ -16,6 +10,7 @@ MagicMirror² version >= 2.15.0 required.
 * Config option: `showBrand`
 * Integrated MagicMirror logger on server side
 * Dependency: `node-html-parser`
+* Config option `excludeStationIds` to exclude gas stations from radius (Tankerkönig only)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # MMM-Fuel Changelog
 
+## [2.2.2]
+
+### Added
+
+* Config option `excludeStationIds` to exclude gas stations from radius (Tankerkönig only)
+
 ## [2.2.1]
 
 ### Fixed

--- a/MMM-Fuel.css
+++ b/MMM-Fuel.css
@@ -7,7 +7,7 @@
     margin-right: 5px;
 }
 
-.MMM-Fuel .sortBy {
+.MMM-Fuel .sort-By {
     margin-left: 5px;
 }
 

--- a/MMM-Fuel.css
+++ b/MMM-Fuel.css
@@ -7,7 +7,7 @@
     margin-right: 5px;
 }
 
-.MMM-Fuel .sort-By {
+.MMM-Fuel .sort-by {
     margin-left: 5px;
 }
 

--- a/MMM-Fuel.js
+++ b/MMM-Fuel.js
@@ -83,7 +83,9 @@ Module.register('MMM-Fuel', {
         rotateInterval: 60 * 1000, // every minute
         updateInterval: 15 * 60 * 1000, // every 15 minutes
         provider: 'tankerkoenig',
-        toFixed: false
+        toFixed: false,        
+        stationIds: [],
+        excludeStationIds: []
     },
 
     /**

--- a/MMM-Fuel.js
+++ b/MMM-Fuel.js
@@ -83,7 +83,7 @@ Module.register('MMM-Fuel', {
         rotateInterval: 60 * 1000, // every minute
         updateInterval: 15 * 60 * 1000, // every 15 minutes
         provider: 'tankerkoenig',
-        toFixed: false,        
+        toFixed: false,
         stationIds: [],
         excludeStationIds: []
     },

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ or your API access will be suspended.
 | `types` | `["diesel"]` | Valid options are `diesel`, `e5` and `e10`. |
 | `radius` | `5` | Valid range is 0-25. Set to 0 to disable. Not required if `stationIds` are provided. |
 | `stationIds` | `[]` | Optional array of fuel station ids to fetch instead of the radius. You can only specify a maximum of 10 and you can find the ids [here](https://creativecommons.tankerkoenig.de/TankstellenFinder/index.html). Using radius and station ids in parallel will result in more API calls. If you run into issues increase the `updateInterval`. |
+| `excludeStationIds` | `[]` | Optional array of fuel station ids to exclude from the radius. This is useful e.g. if you got a non public or truck exclusive station in the radius. You can find the ids [here](https://creativecommons.tankerkoenig.de/TankstellenFinder/index.html).|
 
 ### spritpreisrechner (Austria only)
 

--- a/apis/tankerkoenig.js
+++ b/apis/tankerkoenig.js
@@ -106,10 +106,8 @@ function sortByDistance(a, b) {
  * @returns {boolean} To keep or filter the station.
  */
 function filterStations(station) {
-    const excludeStations = Array.isArray(config.excludeStationIds);
-
     for (let i = 0; i < config.types.length; i += 1) {
-        if (station[config.types[i]] <= 0 || config.showOpenOnly && !station.isOpen || excludeStations && config.excludeStationIds.includes(station.id)) {
+        if (station[config.types[i]] <= 0 || config.showOpenOnly && !station.isOpen || config.excludeStationIds.includes(station.id)) {
             return false;
         }
     }
@@ -316,11 +314,9 @@ async function getData() {
     if (config.radius > 0) {
         stations = stations.concat(await getPricesByRadius());
     }
-
-    if (Array.isArray(config.stationIds)) {
-        stations = stations.concat(await getPricesByStationList(stations));
-    }
-
+    
+    stations = stations.concat(await getPricesByStationList(stations));
+    
     const stationsFiltered = stations.filter(filterStations);
     stationsFiltered.forEach(normalizeStations);
 

--- a/apis/tankerkoenig.js
+++ b/apis/tankerkoenig.js
@@ -314,9 +314,9 @@ async function getData() {
     if (config.radius > 0) {
         stations = stations.concat(await getPricesByRadius());
     }
-    
+
     stations = stations.concat(await getPricesByStationList(stations));
-    
+
     const stationsFiltered = stations.filter(filterStations);
     stationsFiltered.forEach(normalizeStations);
 

--- a/apis/tankerkoenig.js
+++ b/apis/tankerkoenig.js
@@ -106,8 +106,10 @@ function sortByDistance(a, b) {
  * @returns {boolean} To keep or filter the station.
  */
 function filterStations(station) {
+    const excludeStations = Array.isArray(config.excludeStationIds);
+
     for (let i = 0; i < config.types.length; i += 1) {
-        if (station[config.types[i]] <= 0 || config.showOpenOnly && !station.isOpen) {
+        if (station[config.types[i]] <= 0 || config.showOpenOnly && !station.isOpen || excludeStations && config.excludeStationIds.includes(station.id)) {
             return false;
         }
     }

--- a/templates/MMM-Fuel.njk
+++ b/templates/MMM-Fuel.njk
@@ -21,7 +21,7 @@
                     <th class="centered">
                         <span>{{ type | capitalizeFirstLetter }}</span>
                         {% if sortByPrice and config.sortBy == type %}
-                            <i class="fa fa-long-arrow-down sortBy"></i>
+                            <i class="fa fa-long-arrow-down sort-By"></i>
                         {% endif %}
                     </th>
                 {% endif %}
@@ -30,7 +30,7 @@
                 <th class="centered">
                     <i class="fa fa-map-o"></i>
                     {% if not sortByPrice %}
-                        <i class="fa fa-long-arrow-down sortBy"></i>
+                        <i class="fa fa-long-arrow-down sort-By"></i>
                     {% endif %}
                 </th>
             {% endif %}

--- a/templates/MMM-Fuel.njk
+++ b/templates/MMM-Fuel.njk
@@ -21,7 +21,7 @@
                     <th class="centered">
                         <span>{{ type | capitalizeFirstLetter }}</span>
                         {% if sortByPrice and config.sortBy == type %}
-                            <i class="fa fa-long-arrow-down sort-By"></i>
+                            <i class="fa fa-long-arrow-down sort-by"></i>
                         {% endif %}
                     </th>
                 {% endif %}
@@ -30,7 +30,7 @@
                 <th class="centered">
                     <i class="fa fa-map-o"></i>
                     {% if not sortByPrice %}
-                        <i class="fa fa-long-arrow-down sort-By"></i>
+                        <i class="fa fa-long-arrow-down sort-by"></i>
                     {% endif %}
                 </th>
             {% endif %}


### PR DESCRIPTION
Added option excludeStationIds to exclude stationIds from radius search result. This is useful e.g. if you got a non public or truck exclusive station in the radius.