### PR TITLE
custom header text

### DIFF
--- a/MMM-Fuel.js
+++ b/MMM-Fuel.js
@@ -161,6 +161,7 @@ Module.register('MMM-Fuel', {
 
         return {
             config: this.config,
+			header: this.data.header,
             priceList: this.priceList,
             sortByPrice: this.sortByPrice,
             gasStations

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Gas Station Price Module for MagicMirror<sup>2</sup>
 | `showOpenOnly` | `false` | Boolean to show only open gas stations or all. |
 | `showDistance` | `true` | Boolean to show the distance to your specified position. |
 | `showBrand` | `false` | Boolean to show the brand instead of the name. |
-| `iconHeader` | `true` | Boolean to display the car icon in the header. |
+| `iconHeader` | `true` | Boolean to display the car icon in the header (works only if no custom header is set). |
 | `rotate` | `true` | Boolean to enable/disable rotation between sort by price and distance. |
 | `rotateInterval` | `60000` (1 min) | How fast the sorting should be switched between byPrice and byDistance. |
 | `updateInterval` | `900000` (15 mins) | How often should the data be fetched. **If your value is to small, you risk to get banned from the API provider. I suggest a minimum of 15mins** |

--- a/templates/MMM-Fuel.njk
+++ b/templates/MMM-Fuel.njk
@@ -1,9 +1,12 @@
-<header class="align-left">
-    {% if config.iconHeader %}
-        <i class="fa fa-car logo"></i>
-    {% endif %}
-    <span>{{ "FUEL_PRICES" | translate }}</span>
-</header>
+{% if not header %}
+    <header class="align-left">
+        {% if config.iconHeader %}
+            <i class="fa fa-car logo"></i>
+        {% endif %}
+            
+        <span>{{ "FUEL_PRICES" | translate }}</span>
+    </header>
+{% endif %}
 {% if not priceList %}
     <div class="dimmed light">{{ "LOADING" | translate | safe }}</div>
 {% else %}


### PR DESCRIPTION
If you want to set a custom header text then two headers will be shown. Example config:

```
module: "MMM-Fuel",
position: "top_left",
header: "⛽ Spritpreise",
config: {
    provider: "spritpreisrechner",
    lat: <lat>,
    lng: <lng>,
    max: 3,
    types: ["diesel", "e5"],
    showDistance: false,
    showAddressCity: false,
    iconHeader: false,
    rotate: false,
    updateInterval: 30 * 60 * 1000,
    fade: false
}
```
			
Screenshot:

![custom header](https://user-images.githubusercontent.com/35005352/205269881-40674f79-8c70-4b59-a42f-520ae45ba892.png)

I added a check for a custom header text.