### PR TITLE
Maps integration without voice/modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Gas Station Price Module for MagicMirror<sup>2</sup>
 | `open` | `false` | Display whether the gas station is open or not. |
 | `radius` | `5` | Lookup Area for Gas Stations in km. |
 | `max` | `5` | How many gas stations should be displayed. |
-| `showMapIntegrated` | `false` | Show Google Maps independant from voice commands. |
+| `showMapIntegrated` | `false` | Show Maps independant from voice/modal. |
 | `map_api_key` | `false` | Required to show the gas stations map with traffic layer. You can get it [here](https://console.developers.google.com/) and don't forget to activate maps api for javascript. |
 | `zoom` | `12` | Zoom of the map. (Min 0, Max 18 depends on the area) |
 | `height` | `600` | Height of the map in pixel. |

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Gas Station Price Module for MagicMirror<sup>2</sup>
 | `open` | `false` | Display whether the gas station is open or not. |
 | `radius` | `5` | Lookup Area for Gas Stations in km. |
 | `max` | `5` | How many gas stations should be displayed. |
+| `showMapIntegrated` | `false` | Show Google Maps independant from voice commands. |
 | `map_api_key` | `false` | Required to show the gas stations map with traffic layer. You can get it [here](https://console.developers.google.com/) and don't forget to activate maps api for javascript. |
 | `zoom` | `12` | Zoom of the map. (Min 0, Max 18 depends on the area) |
 | `height` | `600` | Height of the map in pixel. |


### PR DESCRIPTION
As the title suggests, this addition just brings the possibility to show the Maps integrated without the need for voice or modal module. This adjustments are more a draft than a really good and well coded solution. And well, i tried to solve a feature request from the past. I wanted it too. My Mirror don't have any microphones or speakers connected. So i have not passed any tests with microphone. There could maybe side effects i'm not aware of.

I added also a map marker icon as svg style. But without configurable options.
I changed the max visible map marker output to the 'max' configurable option.

For usage, i added a new variable to config.js MMM-Fuel config part:
showMapIntegrated: true,

So, feel free to take this as a idea for further development.
